### PR TITLE
feat: Add last modified timestamp to nodes

### DIFF
--- a/canonicalwebteam/sitemaps_parser/app.py
+++ b/canonicalwebteam/sitemaps_parser/app.py
@@ -1,4 +1,6 @@
 import re
+import os
+from datetime import datetime
 from contextlib import suppress
 from pathlib import Path
 
@@ -245,6 +247,7 @@ def create_node():
         "description": None,
         "link": None,
         "children": [],
+        "last_modified": None,
     }
 
 
@@ -277,6 +280,11 @@ def scan_directory(path_name, base=None):
             # Get tags, add as child
             tags = get_tags_rolling_buffer(index_path)
             node = update_tags(node, tags)
+            # Add last modified time for index.html
+            lastmod_time = os.path.getmtime(index_path)
+            node["last_modified"] = datetime.fromtimestamp(
+                lastmod_time
+            ).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # Cycle through other files in this directory
     for child in node_path.iterdir():
@@ -292,6 +300,12 @@ def scan_directory(path_name, base=None):
                     child_tags["link"] = get_extended_copydoc(
                         extended_path, base=base
                     )
+                # Add last modified time for child paths
+                lastmod_time = os.path.getmtime(child)
+                child_tags["last_modified"] = datetime.fromtimestamp(
+                    lastmod_time
+                ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
                 node["children"].append(child_tags)
         # If the child is a directory, scan it
         if child.is_dir():

--- a/canonicalwebteam/sitemaps_parser/app.py
+++ b/canonicalwebteam/sitemaps_parser/app.py
@@ -1,6 +1,5 @@
 import re
-import os
-from datetime import datetime
+import subprocess
 from contextlib import suppress
 from pathlib import Path
 
@@ -251,6 +250,22 @@ def create_node():
     }
 
 
+def get_git_last_modified_time(path):
+    """
+    Get the last modified time of a file using Git metadata.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "log", "-1", "--format=%cI", str(path)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError:
+        return None
+
+
 def scan_directory(path_name, base=None):
     """
     We scan a given directory for valid pages and return a tree
@@ -281,10 +296,9 @@ def scan_directory(path_name, base=None):
             tags = get_tags_rolling_buffer(index_path)
             node = update_tags(node, tags)
             # Add last modified time for index.html
-            lastmod_time = os.path.getmtime(index_path)
-            node["last_modified"] = datetime.fromtimestamp(
-                lastmod_time
-            ).strftime("%Y-%m-%dT%H:%M:%SZ")
+            lastmod_time = get_git_last_modified_time(index_path)
+            if lastmod_time:
+                node["last_modified"] = lastmod_time
 
     # Cycle through other files in this directory
     for child in node_path.iterdir():
@@ -301,10 +315,9 @@ def scan_directory(path_name, base=None):
                         extended_path, base=base
                     )
                 # Add last modified time for child paths
-                lastmod_time = os.path.getmtime(child)
-                child_tags["last_modified"] = datetime.fromtimestamp(
-                    lastmod_time
-                ).strftime("%Y-%m-%dT%H:%M:%SZ")
+                child_lastmod_time = get_git_last_modified_time(child)
+                if child_lastmod_time:
+                    child_tags["last_modified"] = child_lastmod_time
 
                 node["children"].append(child_tags)
         # If the child is a directory, scan it

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.sitemaps-parser",
-    version="1.0.2",
+    version="1.0.3",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.sitemaps-parser",


### PR DESCRIPTION
## Done

- Add `last_modified` dates to tree nodes
- Use `git log` to get last modified dates of files

## QA

- Go to https://ubuntu-com-14842.demos.haus/sitemap_parser
- See that `last_modified` key-value pair is present for tree nodes

### Check if PR is ready for release

If this PR contains code changes, it should contain the following changes to make sure it's ready for the release:

- [x] Package version in `setup.py` should be updated relative to the [most recent release](https://github.com/canonical/canonicalwebteam.sitemaps-parser/releases/latest)


## Issue / Card

Fixes [WD-17183](https://warthogs.atlassian.net/browse/WD-17183)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17183]: https://warthogs.atlassian.net/browse/WD-17183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ